### PR TITLE
Remove manual logstash process management

### DIFF
--- a/src/init/dmon-ls.conf
+++ b/src/init/dmon-ls.conf
@@ -1,0 +1,28 @@
+description "Logstash service"
+
+start on (net-device-up
+          and local-filesystems
+          and runlevel [2345])
+stop on runlevel [016]
+
+respawn
+respawn limit 10 30
+
+limit nofile 32000 32000
+
+setuid ubuntu
+setgid ubuntu
+
+env heap_size="1g"
+
+script
+
+  HOME="/opt/logstash"
+  LS_JAVA_OPTS="-Djava.io.tmpdir=/opt/logstash"
+  LS_HEAP_SIZE="$heap_size"
+  export HOME LS_HEAP_SIZE LS_JAVA_OPTS
+  exec /opt/logstash/bin/logstash agent \
+    -f /opt/DICE-Monitoring/src/conf/logstash.conf \
+    -l /opt/DICE-Monitoring/src/logs/logstash.log
+
+end script


### PR DESCRIPTION
Logstash process management has been delegated to system's init system and manually killing them is not an option anymore, since this can create some really nasty race conditions. This pull requests removes offending code and redirects all of the process management to init helpers.

Note that because of this change, dmon now needs to run as root user. It would be better to have dmon call sudo for any operations that need elevated privileges, but this change would affect large parts of the DMon's code, so it was not done in this pull request,