### PR TITLE
Teach DMon agent about Apache Storm 1.x logs

### DIFF
--- a/bootstrap/blueprint.yaml
+++ b/bootstrap/blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-  - https://github.com/dice-project/DICE-Deployment-Cloudify/releases/download/0.7.1/full.yaml
+  - https://github.com/dice-project/DICE-Deployment-Cloudify/releases/download/0.7.4/full.yaml
 
 inputs:
 


### PR DESCRIPTION
Previously, DMon agent only knew how to handle logfiles from Apache
Storm version 0.9.x. Updates in this commit make sure DMon agent now
properly handles logs from version 1.0.x as well.